### PR TITLE
Separating test suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
         - php: nightly
     fast_finish: true
     include:
-        - php: 7.1
-        - php: 7.2
-        - php: nightly
+        - php: '7.1'
+        - php: '7.2'
+        - php: 'nightly'
 
 env:
   - TRAVIS_NODE_VERSION="stable"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     }
   ],
   "scripts": {
-    "test:unit": "./vendor/bin/phpunit --color",
+    "test": "./vendor/bin/phpunit --color",
+    "test:unit": "./vendor/bin/phpunit --color --testsuite Unit",
+    "test:integration": "./vendor/bin/phpunit --color --testsuite Integration",
     "test:typing": "./vendor/bin/phpstan analyse --level max src",
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,12 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="WebPush Test Suite">
-            <directory suffix=".php">./tests/</directory>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -89,6 +89,11 @@ class WebPush
         if (!array_key_exists('timeout', $clientOptions) && isset($timeout)) {
             $clientOptions['timeout'] = $timeout;
         }
+
+        if (array_key_exists('http_errors', $clientOptions)) {
+            $clientOptions['http_errors'] = false;
+        }
+
         $this->client = new Client($clientOptions);
     }
 

--- a/tests/Integration/PushServiceTest.php
+++ b/tests/Integration/PushServiceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Integration;
 
 /*
  * This file is part of the WebPush library.
@@ -48,10 +48,6 @@ final class PushServiceTest extends TestCase
      */
     protected function setUp()
     {
-        if (!(getenv('TRAVIS') || getenv('CI'))) {
-            $this->markTestSkipped('This test does not run on Travis.');
-        }
-
         $startApiCurl = curl_init(self::$testServiceUrl.'/api/start-test-suite/');
         curl_setopt_array($startApiCurl, [
             CURLOPT_POST => true,

--- a/tests/Integration/WebPushTest.php
+++ b/tests/Integration/WebPushTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Integration;
 
 /*
  * This file is part of the WebPush library.
@@ -13,6 +13,7 @@ namespace Minishlink\WebPush\Tests;
  * file that was distributed with this source code.
  */
 
+use ErrorException;
 use Minishlink\WebPush\MessageSentReport;
 use Minishlink\WebPush\WebPush;
 use Minishlink\WebPush\Subscription;
@@ -80,11 +81,6 @@ final class WebPushTest extends TestCase
     public function notificationProvider(): array
     {
         self::setUpBeforeClass(); // dirty hack of PHPUnit limitation
-
-        // ignore in TravisCI
-        if (getenv('CI')) {
-            return [];
-        }
 
         return [
             [new Subscription(self::$endpoints['standard'], self::$keys['standard'], self::$tokens['standard']), '{"message":"Comment ça va ?","tag":"general"}'],

--- a/tests/Unit/EncryptionTest.php
+++ b/tests/Unit/EncryptionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 /*
  * This file is part of the WebPush library.

--- a/tests/Unit/MessageSentReportTest.php
+++ b/tests/Unit/MessageSentReportTest.php
@@ -4,7 +4,7 @@
  * @started: 2018-12-03 11:31
  */
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 use GuzzleHttp\Psr7\Request;
 use \Minishlink\WebPush\MessageSentReport;

--- a/tests/Unit/NotificationTest.php
+++ b/tests/Unit/NotificationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 use Minishlink\WebPush\Notification;
 use Minishlink\WebPush\Subscription;

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 use Minishlink\WebPush\Subscription;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 use Jose\Component\Core\Util\Ecc\NistCurve;
 use Minishlink\WebPush\Utils;

--- a/tests/Unit/VAPIDTest.php
+++ b/tests/Unit/VAPIDTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Minishlink\WebPush\Tests;
+namespace Minishlink\WebPush\Tests\Unit;
 
 /*
  * This file is part of the WebPush library.


### PR DESCRIPTION
Clear separation of unit and integration tests will allow for an easier on-boarding experience as well as CI interactions for developers as they no longer have to inspect each testcase individually to understand why so many are being skipped, failing, or otherwise